### PR TITLE
Shift to pip install for wdmtoolbox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ RUN apt-get update && apt-get install -y \
       unzip \
       wget
 
-RUN conda install -y -c https://conda.anaconda.org/timcera wdmtoolbox
+RUN pip install wdmtoolbox
 
 COPY README.md README.md


### PR DESCRIPTION
Thanks for using wdmtoolbox.  I hope it is useful.

I stopped updating my conda repository a long time ago, and removed the files about a month ago, so your unchanged Dockerfile wouldn't build wdmtoolbox anymore.

I now use a pure "pip" install which is pretty easy to shift in your Dockerfile since the anaconda base has almost everything installed already.

Kindest regards,
Tim
